### PR TITLE
Spawning on a pipe doesn't trigger its effect now

### DIFF
--- a/src/macaroni/model/character/Character.java
+++ b/src/macaroni/model/character/Character.java
@@ -24,10 +24,12 @@ public abstract class Character {
     public Character(Element location) {
         boolean success = moveTo(location);
         if (!success) {
-            throw new IllegalArgumentException(
-                    "Character can't be constructed at location " + location +
-                    " because the element refused the entry request."
-            );
+            String message = "Character can't be constructed at location " +
+                    location +
+                    " because the element refused the entry request.\n" +
+                    "Ensure the element is in a valid state and can be moved to " +
+                    "(for example a pipe is not occupied and both its ends are connected).";
+            throw new IllegalArgumentException(message);
         }
     }
 

--- a/src/macaroni/model/element/Pipe.java
+++ b/src/macaroni/model/element/Pipe.java
@@ -110,16 +110,16 @@ public class Pipe extends Element {
     public boolean enter(Character character, Element from) {
         if (!occupied && endpoints.size() == 2) {
             if (from == null) {
-                Random.setCharacterLocationBeforeEnteringPipe(this, endpoints.get(0));
+                if (character.leave(this)) {
+                    occupied = true;
+                    return true;
+                }
             } else if (neighbours.contains(from)) {
                 Random.setCharacterLocationBeforeEnteringPipe(this, from);
-            } else {
-                return false;
-            }
-
-            if (effect.enter(character)) {
-                occupied = true;
-                return true;
+                if (effect.enter(character)) {
+                    occupied = true;
+                    return true;
+                }
             }
         }
         return false;


### PR DESCRIPTION
Fix design problem introduced in #17 where you can't spawn on a pipe with a banana effect.