### PR TITLE
Macos fixes

### DIFF
--- a/src/macaroni/app/AssetManager.java
+++ b/src/macaroni/app/AssetManager.java
@@ -27,7 +27,7 @@ public class AssetManager {
     static {
         try (Stream<Path> fontStream = Files.walk(Path.of("./assets/fonts"));
              Stream<Path> imgStream = Files.walk(Path.of("./assets/images"))) {
-            fontStream.filter(path -> Files.isRegularFile(path) && !path.endsWith("OFL.txt"))
+            fontStream.filter(path -> Files.isRegularFile(path) && path.toString().endsWith(".ttf"))
                     .forEach(path ->
                     {
                         try {

--- a/src/macaroni/app/Window.java
+++ b/src/macaroni/app/Window.java
@@ -27,6 +27,15 @@ public final class Window extends JFrame {
         setIgnoreRepaint(true);
         setUndecorated(true);
 
+
+        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+            // TODO this works for fullscreen, but still has some issues (can't exit it, only by Cmd+Q)
+            // https://github.com/ymasory/OrangeExtensions
+            GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+            GraphicsDevice myDevice = ge.getDefaultScreenDevice();
+            myDevice.setFullScreenWindow(this);
+        }
+
         getContentPane().setLayout(new CardLayout());
         Controller controller = new Controller(this);
         add(new MainMenu(controller, getSize()), Controller.MenuTag.MAIN.toString());


### PR DESCRIPTION
Fixed font loading exceptions, and half-fixed fullscreen mode. Fullscreen works now, but you can only exit the application using Cmd+Q. This will need to be improved later.

Fixes #26