### PR TITLE
Fix compile warning due to UTF-8 characters in the source code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,7 @@ jacocoTestReport {
         }))
     }
 }
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8' // Use the UTF-8 charset for Java compilation
+}


### PR DESCRIPTION
Fixes the warning in `CommandInterpreter`